### PR TITLE
refactor(chatbot): unified input box — HTML, CSS, Playwright tests

### DIFF
--- a/_includes/chatbot_shell.html
+++ b/_includes/chatbot_shell.html
@@ -1,5 +1,5 @@
 {%- comment -%}
-Global chatbot shell (Iteration 4)
+Global chatbot shell (Iteration 5)
 - Rendered only on allowlisted DM content pages (see _config.yml -> chatbot)
 - Excluded on /tools/* and other denylisted pages
 {%- endcomment -%}
@@ -8,19 +8,16 @@ Global chatbot shell (Iteration 4)
   // Apply persisted open/closed state before the widget renders to reduce flicker.
   (function () {
     try {
-      var key = 'dnd_global_chatbot_open';
-      var open = localStorage.getItem(key);
-      if (open === 'false') {
-        document.documentElement.classList.add('chatbot-collapsed');
-      }
-    } catch (_) {
-      // ignore
-    }
+      var open = localStorage.getItem('dnd_global_chatbot_open');
+      if (open === 'false') document.documentElement.classList.add('chatbot-collapsed');
+    } catch (_) {}
   })();
 </script>
 
 <aside id="global-chatbot" class="chatbot" aria-label="AI Assistant">
   <div class="chatbot__panel">
+
+    <!-- ── Header ── -->
     <div class="chatbot__header">
       <div class="chatbot__title">
         <span class="chatbot__badge" aria-hidden="true">AI</span>
@@ -29,36 +26,150 @@ Global chatbot shell (Iteration 4)
           <div class="chatbot__subheading">DM tools</div>
         </div>
       </div>
-
-      <button id="chatbotToggle" class="btn btn-sm btn-outline-secondary chatbot__toggle" type="button" aria-label="Toggle chatbot">
+      <button id="chatbotToggle" class="btn btn-sm btn-outline-secondary chatbot__toggle"
+              type="button" aria-label="Toggle chatbot">
         <span class="chatbot__toggleIcon" aria-hidden="true">›</span>
       </button>
     </div>
 
-    <div class="chatbot__toolbar">
-      <div class="chatbot__toolbarRow">
-        <select id="chatbotProvider" class="form-select form-select-sm chatbot__select" aria-label="LLM provider"></select>
-        <select id="chatbotKind" class="form-select form-select-sm chatbot__select" aria-label="Generate type"></select>
-      </div>
-      <div class="chatbot__toolbarRow chatbot__toolbarRow--icons" aria-hidden="true">
-        <button class="btn btn-sm btn-outline-secondary" type="button" disabled>Attach</button>
-        <button class="btn btn-sm btn-outline-secondary" type="button" disabled>Model</button>
-        <button class="btn btn-sm btn-outline-secondary" type="button" disabled>Tools</button>
-      </div>
-    </div>
+    <!-- ── Messages ── -->
+    <div id="chatbotMessages" class="chatbot__messages"
+         role="log" aria-live="polite" aria-relevant="additions"></div>
 
-    <div id="chatbotMessages" class="chatbot__messages" role="log" aria-live="polite" aria-relevant="additions"></div>
+    <!-- ── Unified input box ── -->
+    <div class="chatbot__inputArea">
 
-    <div class="chatbot__input">
-      <textarea id="chatbotInput" class="form-control chatbot__textarea" rows="1" placeholder="Ask me anything..." aria-label="Chat input"></textarea>
-      <div class="chatbot__inputRow">
-        <div class="chatbot__hint">Sends your prompt to the selected generator.</div>
-        <button id="chatbotSend" class="btn btn-primary chatbot__send" type="button">Send</button>
-      </div>
-    </div>
-  </div>
+      <!-- Attachment preview strip (hidden until files are attached) -->
+      <div id="chatbotAttachments" class="chatbot__attachments" hidden></div>
+      <div id="chatbotAttachError" class="chatbot__attachError" hidden></div>
 
-  <button id="chatbotFloatingToggle" class="btn btn-primary chatbot__floatingToggle" type="button" aria-label="Show chatbot">
+      <!-- Input box: focus ring wraps textarea + bottom bar -->
+      <div class="chatbot__inputBox" data-mode="ask" id="chatbotInputBox">
+
+        <textarea id="chatbotInput"
+                  class="chatbot__textarea"
+                  rows="1"
+                  placeholder="Ask anything..."
+                  aria-label="Chat input"></textarea>
+
+        <!-- Bottom action bar -->
+        <div class="chatbot__bottomBar">
+
+          <!-- Left controls -->
+          <div class="chatbot__bottomLeft">
+
+            <!-- Mode toggle: Ask / Agent -->
+            <div class="chatbot__dropdownWrap" id="modeDropdownWrap">
+              <button class="chatbot__pillBtn chatbot__pillBtn--active"
+                      type="button"
+                      data-testid="mode-toggle"
+                      id="modePillBtn"
+                      aria-haspopup="true"
+                      aria-expanded="false">
+                <svg class="chatbot__pillIcon" aria-hidden="true" viewBox="0 0 16 16" width="14" height="14">
+                  <path fill="currentColor" d="M2 2h12v8H9l-3 3v-3H2z"/>
+                </svg>
+                <span id="modePillLabel">Ask</span>
+                <svg class="chatbot__chevron" aria-hidden="true" viewBox="0 0 16 16" width="10" height="10">
+                  <path fill="currentColor" d="M4 6l4 4 4-4"/>
+                </svg>
+              </button>
+              <ul class="chatbot__dropdownMenu" id="modeMenu" role="menu" hidden>
+                <li role="menuitem" data-value="ask">
+                  <svg aria-hidden="true" viewBox="0 0 16 16" width="14" height="14">
+                    <path fill="currentColor" d="M2 2h12v8H9l-3 3v-3H2z"/>
+                  </svg>
+                  Ask
+                </li>
+                <li role="menuitem" data-value="agent">
+                  <svg aria-hidden="true" viewBox="0 0 16 16" width="14" height="14">
+                    <path fill="currentColor" d="M8 1a5 5 0 100 10A5 5 0 008 1zm0 2a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0 7c-2 0-3.5-1-3.5-2.5C4.5 6 6 5 8 5s3.5 1 3.5 2.5C11.5 9 10 10 8 10z"/>
+                  </svg>
+                  Agent
+                </li>
+              </ul>
+            </div>
+
+            <!-- Agent type selector — only visible in agent mode -->
+            <div class="chatbot__dropdownWrap" id="agentTypeWrap">
+              <button class="chatbot__pillBtn"
+                      type="button"
+                      data-testid="agent-type-btn"
+                      id="agentTypePillBtn"
+                      aria-haspopup="true"
+                      aria-expanded="false">
+                <svg class="chatbot__pillIcon" aria-hidden="true" viewBox="0 0 16 16" width="14" height="14">
+                  <path fill="currentColor" d="M1 3h14v2H1zm2 4h10v2H3zm2 4h6v2H5z"/>
+                </svg>
+                <span id="agentTypePillLabel">NPC</span>
+                <svg class="chatbot__chevron" aria-hidden="true" viewBox="0 0 16 16" width="10" height="10">
+                  <path fill="currentColor" d="M4 6l4 4 4-4"/>
+                </svg>
+              </button>
+              <ul class="chatbot__dropdownMenu" id="agentTypeMenu" role="menu" hidden></ul>
+            </div>
+
+            <!-- Attach button -->
+            <button class="chatbot__pillBtn chatbot__pillBtn--icon"
+                    type="button"
+                    data-testid="attach-btn"
+                    id="attachBtn"
+                    aria-label="Attach file">
+              <svg aria-hidden="true" viewBox="0 0 16 16" width="15" height="15">
+                <path fill="currentColor" d="M13.5 6.5l-6 6a3.5 3.5 0 01-4.95-4.95l6-6a2 2 0 012.83 2.83l-5.66 5.66a.5.5 0 01-.71-.71l5.66-5.66"/>
+              </svg>
+            </button>
+
+            <!-- Hidden real file input -->
+            <input type="file"
+                   id="chatbotFileInput"
+                   class="chatbot__fileInput"
+                   accept="image/*,.pdf,.doc,.docx,.txt,.md,.json"
+                   multiple
+                   hidden>
+          </div>
+
+          <!-- Right controls: model selector + send -->
+          <div class="chatbot__bottomRight">
+            <div class="chatbot__dropdownWrap" id="modelDropdownWrap">
+              <button class="chatbot__modelBtn"
+                      type="button"
+                      data-testid="model-btn"
+                      id="modelBtn"
+                      aria-haspopup="true"
+                      aria-expanded="false">
+                <span id="modelBtnLabel">Loading…</span>
+                <svg class="chatbot__chevron" aria-hidden="true" viewBox="0 0 16 16" width="10" height="10">
+                  <path fill="currentColor" d="M4 6l4 4 4-4"/>
+                </svg>
+              </button>
+              <ul class="chatbot__dropdownMenu chatbot__modelDropdown"
+                  id="modelMenu" role="menu" hidden></ul>
+            </div>
+
+            <div class="chatbot__sendDivider" aria-hidden="true"></div>
+
+            <button id="chatbotSend"
+                    class="chatbot__sendBtn"
+                    type="button"
+                    data-testid="send-btn"
+                    aria-label="Send message">
+              <svg aria-hidden="true" viewBox="0 0 16 16" width="15" height="15">
+                <path fill="currentColor" d="M2 14L14 8 2 2v4l8 2-8 2z"/>
+              </svg>
+            </button>
+          </div>
+
+        </div><!-- /.chatbot__bottomBar -->
+      </div><!-- /.chatbot__inputBox -->
+    </div><!-- /.chatbot__inputArea -->
+
+  </div><!-- /.chatbot__panel -->
+
+  <button id="chatbotFloatingToggle"
+          class="btn btn-primary chatbot__floatingToggle"
+          type="button"
+          aria-label="Show chatbot">
     <span aria-hidden="true">‹</span>
   </button>
 </aside>

--- a/assets/css/chatbot.css
+++ b/assets/css/chatbot.css
@@ -1,26 +1,17 @@
-/* Global chatbot (Iteration 4)
- *
- * Styling constraints:
- * - Prefer Bootstrap variables and existing typography.
- * - Avoid introducing new color tokens.
- * - Scope styles to the chatbot wrapper so existing pages/layouts remain stable.
+/* Global chatbot (Iteration 5)
+ * - Prefer Bootstrap variables.
+ * - Scope all rules to #global-chatbot to avoid bleed.
  */
 
-/* Split-view layout (desktop/tablet)
- * Support both the current wrapper (#chatbot-split) and the legacy wrapper
- * (#page-container) to avoid regressing to a stacked layout.
- */
-/* Enforce split layout: 2/3 content, 1/3 chatbot. Use higher specificity to avoid overrides. */
+/* ── Split-view layout (desktop) ── */
 #split-wrapper.with-chatbot {
   display: flex !important;
   min-height: 100vh !important;
 }
-
 #split-wrapper.with-chatbot > #page-container {
   flex: 0 0 66.6666667% !important;
   max-width: 66.6666667% !important;
 }
-
 #split-wrapper.with-chatbot > #chatbot-column {
   flex: 0 0 33.3333333% !important;
   max-width: 33.3333333% !important;
@@ -28,248 +19,364 @@
   position: relative;
 }
 
-/* Panel shell */
-#global-chatbot.chatbot {
-  position: relative;
-}
+/* ── Panel shell ── */
+#global-chatbot.chatbot { position: relative; }
 
 #global-chatbot .chatbot__panel {
   height: 100%;
   display: flex;
   flex-direction: column;
-  border-left: 1px solid rgba(255, 255, 255, 0.12);
+  border-left: 1px solid rgba(255,255,255,.12);
   background: var(--bs-body-bg);
   transition: opacity 200ms ease, transform 200ms ease;
 }
 
+/* ── Header ── */
 #global-chatbot .chatbot__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.75rem 0.75rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  padding: .75rem;
+  border-bottom: 1px solid rgba(255,255,255,.12);
+  flex-shrink: 0;
 }
-
 #global-chatbot .chatbot__title {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: .75rem;
 }
-
 #global-chatbot .chatbot__badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 2rem;
   height: 2rem;
-  border-radius: 0.5rem;
-  background: rgba(255, 255, 255, 0.12);
+  border-radius: .5rem;
+  background: rgba(255,255,255,.12);
   font-weight: 600;
 }
+#global-chatbot .chatbot__heading { font-weight: 600; line-height: 1.1; }
+#global-chatbot .chatbot__subheading { font-size: .875rem; opacity: .75; }
+#global-chatbot .chatbot__toggle { min-width: 2.25rem; }
+#global-chatbot .chatbot__toggleIcon { display: inline-block; }
 
-#global-chatbot .chatbot__heading {
-  font-weight: 600;
-  line-height: 1.1;
-}
-
-#global-chatbot .chatbot__subheading {
-  font-size: 0.875rem;
-  opacity: 0.75;
-}
-
-#global-chatbot .chatbot__toggle {
-  min-width: 2.25rem;
-}
-
-#global-chatbot .chatbot__toggleIcon {
-  display: inline-block;
-  transform: rotate(0deg);
-}
-
-#global-chatbot .chatbot__toolbar {
-  padding: 0.75rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-}
-
-#global-chatbot .chatbot__toolbarRow {
-  display: flex;
-  gap: 0.5rem;
-}
-
-#global-chatbot .chatbot__toolbarRow + .chatbot__toolbarRow {
-  margin-top: 0.5rem;
-}
-
-#global-chatbot .chatbot__toolbarRow--icons {
-  opacity: 0.75;
-}
-
-#global-chatbot .chatbot__select {
-  flex: 1 1 auto;
-}
-
+/* ── Messages ── */
 #global-chatbot .chatbot__messages {
   flex: 1 1 auto;
-  overflow: auto;
-  padding: 0.75rem;
+  overflow-y: auto;
+  padding: .75rem;
 }
-
 #global-chatbot .chatbot__msg {
   display: flex;
-  margin-bottom: 0.75rem;
+  margin-bottom: .75rem;
 }
-
-#global-chatbot .chatbot__msg--user {
-  justify-content: flex-end;
-}
-
+#global-chatbot .chatbot__msg--user { justify-content: flex-end; }
 #global-chatbot .chatbot__bubble {
   max-width: 85%;
-  padding: 0.6rem 0.75rem;
-  border-radius: 0.5rem;
+  padding: .6rem .75rem;
+  border-radius: .5rem;
   white-space: pre-wrap;
   word-break: break-word;
+  font-size: .9rem;
 }
-
 #global-chatbot .chatbot__msg--user .chatbot__bubble {
-  background: rgba(13, 110, 253, 0.35); /* Bootstrap primary-ish tint */
-  border: 1px solid rgba(13, 110, 253, 0.25);
+  background: rgba(13,110,253,.35);
+  border: 1px solid rgba(13,110,253,.25);
 }
-
 #global-chatbot .chatbot__msg--ai .chatbot__bubble {
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.10);
+  background: rgba(255,255,255,.08);
+  border: 1px solid rgba(255,255,255,.10);
 }
-
 #global-chatbot .chatbot__meta {
-  margin-top: 0.25rem;
-  font-size: 0.8rem;
-  opacity: 0.75;
+  margin-top: .25rem;
+  font-size: .8rem;
+  opacity: .75;
 }
 
-#global-chatbot .chatbot__input {
-  padding: 0.75rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.12);
+/* ── Input area (outer wrapper) ── */
+#global-chatbot .chatbot__inputArea {
+  padding: .5rem .75rem .75rem;
+  border-top: 1px solid rgba(255,255,255,.12);
   background: var(--bs-body-bg);
+  flex-shrink: 0;
 }
 
+/* ── Attachment preview strip ── */
+#global-chatbot .chatbot__attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .35rem;
+  margin-bottom: .4rem;
+}
+#global-chatbot .chatbot__attachChip {
+  display: inline-flex;
+  align-items: center;
+  gap: .3rem;
+  padding: .2rem .5rem;
+  border-radius: .375rem;
+  background: rgba(255,255,255,.1);
+  font-size: .75rem;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+#global-chatbot .chatbot__attachChip button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  opacity: .6;
+  line-height: 1;
+}
+#global-chatbot .chatbot__attachError {
+  font-size: .75rem;
+  color: var(--bs-danger);
+  margin-bottom: .3rem;
+}
+
+/* ── Unified input box ── */
+#global-chatbot .chatbot__inputBox {
+  border: 1px solid rgba(255,255,255,.18);
+  border-radius: .75rem;
+  background: #0d0d0d;           /* slightly darker than panel bg */
+  padding: .6rem .6rem .4rem;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+#global-chatbot .chatbot__inputBox:focus-within {
+  border-color: #4d90fe;         /* blue focus ring matching image */
+  box-shadow: 0 0 0 1px rgba(77,144,254,.35);
+}
+
+/* ── Textarea inside the box ── */
 #global-chatbot .chatbot__textarea {
+  display: block;
+  width: 100%;
   resize: none;
   overflow: hidden;
+  border: none;
+  background: transparent;
+  color: var(--bs-body-color);
+  padding: 0 .25rem .4rem;
+  font-size: .9rem;
+  line-height: 1.5;
+  outline: none;
+  min-height: 2rem;
 }
+#global-chatbot .chatbot__textarea::placeholder { opacity: .45; }
 
-#global-chatbot .chatbot__inputRow {
-  margin-top: 0.5rem;
+/* ── Bottom action bar ── */
+#global-chatbot .chatbot__bottomBar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.75rem;
+  gap: .25rem;
+  padding-top: .2rem;
+  border-top: 1px solid rgba(255,255,255,.07);
+  margin-top: .25rem;
+}
+#global-chatbot .chatbot__bottomLeft {
+  display: flex;
+  align-items: center;
+  gap: .25rem;
+  flex-wrap: nowrap;
+}
+#global-chatbot .chatbot__bottomRight {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  flex-shrink: 0;
 }
 
-#global-chatbot .chatbot__hint {
-  font-size: 0.8rem;
-  opacity: 0.75;
+/* ── Pill buttons (mode, agent type, attach) ── */
+#global-chatbot .chatbot__pillBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: .3rem;
+  padding: .25rem .55rem;
+  border-radius: .5rem;
+  border: 1px solid rgba(255,255,255,.15);
+  background: rgba(255,255,255,.05);
+  color: var(--bs-body-color);
+  font-size: .78rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 120ms ease;
+}
+#global-chatbot .chatbot__pillBtn:hover {
+  background: rgba(255,255,255,.10);
+}
+#global-chatbot .chatbot__pillBtn--active {
+  border-color: rgba(255,255,255,.28);
+}
+#global-chatbot .chatbot__pillBtn--icon {
+  padding: .25rem .4rem;
+}
+#global-chatbot .chatbot__pillIcon { flex-shrink: 0; }
+#global-chatbot .chatbot__chevron { flex-shrink: 0; opacity: .55; }
+
+/* ── Agent type button: hidden in ask mode ── */
+#global-chatbot .chatbot__inputBox[data-mode="ask"] #agentTypeWrap {
+  display: none;
 }
 
+/* ── Dropdown menus ── */
+#global-chatbot .chatbot__dropdownWrap {
+  position: relative;
+}
+#global-chatbot .chatbot__dropdownMenu {
+  position: absolute;
+  bottom: calc(100% + .35rem);
+  left: 0;
+  z-index: 1060;
+  min-width: 140px;
+  background: #1a1a1a;
+  border: 1px solid rgba(255,255,255,.15);
+  border-radius: .5rem;
+  padding: .25rem 0;
+  list-style: none;
+  margin: 0;
+  box-shadow: 0 4px 16px rgba(0,0,0,.5);
+}
+/* Model dropdown opens to the right to avoid clipping */
+#global-chatbot .chatbot__modelDropdown {
+  left: auto;
+  right: 0;
+  min-width: 200px;
+}
+#global-chatbot .chatbot__dropdownMenu li {
+  display: flex;
+  align-items: center;
+  gap: .45rem;
+  padding: .35rem .75rem;
+  cursor: pointer;
+  font-size: .82rem;
+  white-space: nowrap;
+  transition: background 100ms;
+}
+#global-chatbot .chatbot__dropdownMenu li:hover {
+  background: rgba(255,255,255,.08);
+}
+#global-chatbot .chatbot__dropdownMenu li[aria-selected="true"] {
+  color: #4d90fe;
+}
+/* Group headers inside model dropdown */
+#global-chatbot .chatbot__modelGroup {
+  padding: .25rem .75rem .1rem;
+  font-size: .7rem;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  opacity: .5;
+  cursor: default;
+  pointer-events: none;
+}
+
+/* ── Model button ── */
+#global-chatbot .chatbot__modelBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: .3rem;
+  padding: .25rem .45rem;
+  border: none;
+  background: transparent;
+  color: rgba(255,255,255,.55);
+  font-size: .78rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+#global-chatbot .chatbot__modelBtn:hover { color: var(--bs-body-color); }
+
+/* ── Divider between model and send ── */
+#global-chatbot .chatbot__sendDivider {
+  width: 1px;
+  height: 1.1rem;
+  background: rgba(255,255,255,.2);
+  margin: 0 .35rem;
+}
+
+/* ── Send button ── */
+#global-chatbot .chatbot__sendBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: .45rem;
+  border: none;
+  background: rgba(255,255,255,.08);
+  color: var(--bs-body-color);
+  cursor: pointer;
+  transition: background 120ms;
+}
+#global-chatbot .chatbot__sendBtn:hover {
+  background: #4d90fe;
+  color: #fff;
+}
+
+/* ── Floating toggle ── */
 #global-chatbot .chatbot__floatingToggle {
   display: none;
   position: fixed;
-  right: 0.75rem;
-  bottom: 0.75rem;
+  right: .75rem;
+  bottom: .75rem;
   z-index: 1050;
 }
 
-/* Collapsed state (desktop/tablet): hide panel, expand content */
-html.chatbot-collapsed #chatbot-split.with-chatbot #content-wrap {
-  flex-basis: 100%;
-  max-width: 100%;
-}
-
+/* ── Collapsed state ── */
+html.chatbot-collapsed #chatbot-split.with-chatbot #content-wrap,
 html.chatbot-collapsed #page-container.with-chatbot #content-wrap {
   flex-basis: 100%;
   max-width: 100%;
 }
-
-html.chatbot-collapsed #chatbot-split.with-chatbot #global-chatbot {
-  flex-basis: 0;
-  max-width: 0;
-}
-
+html.chatbot-collapsed #chatbot-split.with-chatbot #global-chatbot,
 html.chatbot-collapsed #page-container.with-chatbot #global-chatbot {
   flex-basis: 0;
   max-width: 0;
 }
-
 html.chatbot-collapsed #global-chatbot .chatbot__panel {
   opacity: 0;
   transform: translateX(24px);
   pointer-events: none;
 }
-
 html.chatbot-collapsed #global-chatbot .chatbot__floatingToggle {
   display: inline-flex;
 }
 
-/* Mobile drawer mode */
+/* ── Mobile drawer ── */
 @media (max-width: 768px) {
   #chatbot-split.with-chatbot,
-  #page-container.with-chatbot {
-    display: block;
-  }
-
+  #page-container.with-chatbot { display: block; }
   #chatbot-split.with-chatbot #content-wrap,
-  #page-container.with-chatbot #content-wrap {
-    max-width: none;
-  }
-
+  #page-container.with-chatbot #content-wrap { max-width: none; }
   #chatbot-split.with-chatbot #global-chatbot,
   #page-container.with-chatbot #global-chatbot {
     position: fixed;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    left: 0; right: 0; bottom: 0;
     max-width: none;
     width: 100%;
     z-index: 1050;
   }
-
   #global-chatbot .chatbot__panel {
     height: 65vh;
     border-left: none;
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
-    box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.25);
-    transform: translateY(0);
-    transition: transform 200ms ease;
+    border-top: 1px solid rgba(255,255,255,.12);
+    box-shadow: 0 -8px 24px rgba(0,0,0,.25);
   }
-
   html.chatbot-collapsed #global-chatbot .chatbot__panel {
     display: flex;
     transform: translateY(100%);
   }
-
-  #global-chatbot .chatbot__floatingToggle {
-    display: none;
-  }
-
-  html.chatbot-collapsed #global-chatbot .chatbot__floatingToggle {
-    display: inline-flex;
-  }
+  #global-chatbot .chatbot__floatingToggle { display: none; }
+  html.chatbot-collapsed #global-chatbot .chatbot__floatingToggle { display: inline-flex; }
 }
 
-/* ---------------------------------------------------------------------
-   Strict 2/3 / 1/3 split enforcement
-   Ensure the entire site content fits into the left 2/3 and the chatbot
-   UI fits into the right 1/3. Disable open/close behaviors and toggles so
-   the layout is always visible and consistent.
-   ------------------------------------------------------------------ */
-
-/* Force split layout and full-height columns */
+/* ── Strict always-visible split (side_by_side layout) ── */
 #chatbot-split.with-chatbot,
 #page-container.with-chatbot {
   display: flex !important;
   min-height: 100vh !important;
 }
-
 #chatbot-split.with-chatbot > #content-wrap,
 #page-container.with-chatbot > #content-wrap {
   flex: 0 0 66.6666667% !important;
@@ -278,7 +385,6 @@ html.chatbot-collapsed #global-chatbot .chatbot__floatingToggle {
   overflow: auto !important;
   z-index: 1;
 }
-
 #chatbot-split.with-chatbot > #global-chatbot,
 #page-container.with-chatbot > #global-chatbot {
   flex: 0 0 33.3333333% !important;
@@ -288,15 +394,11 @@ html.chatbot-collapsed #global-chatbot .chatbot__floatingToggle {
   position: relative !important;
   z-index: 2;
 }
-
-/* Make the panel fill its column (use container height) */
 #global-chatbot .chatbot__panel {
   height: 100% !important;
   display: flex;
   flex-direction: column;
 }
-
-/* Disable collapsed rules so the panel never hides/overlays */
 html.chatbot-collapsed #chatbot-split.with-chatbot > #content-wrap,
 html.chatbot-collapsed #page-container.with-chatbot > #content-wrap,
 html.chatbot-collapsed #chatbot-split.with-chatbot > #global-chatbot,
@@ -308,20 +410,13 @@ html.chatbot-collapsed #global-chatbot .chatbot__panel {
   transform: none !important;
   pointer-events: auto !important;
 }
-
-/* Hide toggle UI (we're always showing both panes) */
 #global-chatbot .chatbot__floatingToggle,
 #chatbotToggle {
   display: none !important;
 }
-
-/* Mobile: keep stacked but respect 2/3/1/3 where possible */
 @media (max-width: 768px) {
   #chatbot-split.with-chatbot,
-  #page-container.with-chatbot {
-    display: block !important;
-  }
-
+  #page-container.with-chatbot { display: block !important; }
   #chatbot-split.with-chatbot > #content-wrap,
   #page-container.with-chatbot > #content-wrap,
   #chatbot-split.with-chatbot > #global-chatbot,

--- a/tests/ui/chat-input-refactor.spec.js
+++ b/tests/ui/chat-input-refactor.spec.js
@@ -1,0 +1,91 @@
+// tests/ui/chat-input-refactor.spec.js
+// Run against a built Jekyll site served at http://localhost:4000
+// Start the site first: bundle exec jekyll serve --livereload
+
+const { test, expect } = require('@playwright/test');
+
+const CHAT_PAGE = 'http://localhost:4000/chapters/'; // first chatbot-enabled page
+
+test.describe('Chat input box layout', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(CHAT_PAGE);
+    // Wait for the widget JS to boot
+    await page.waitForSelector('.chatbot__inputBox');
+  });
+
+  test('input box is present and contains textarea', async ({ page }) => {
+    const box = page.locator('.chatbot__inputBox');
+    await expect(box).toBeVisible();
+    await expect(box.locator('.chatbot__textarea')).toBeVisible();
+  });
+
+  test('bottom bar has mode toggle, attach, model, and send buttons', async ({ page }) => {
+    const bar = page.locator('.chatbot__bottomBar');
+    await expect(bar.locator('[data-testid="mode-toggle"]')).toBeVisible();
+    await expect(bar.locator('[data-testid="attach-btn"]')).toBeVisible();
+    await expect(bar.locator('[data-testid="model-btn"]')).toBeVisible();
+    await expect(bar.locator('[data-testid="send-btn"]')).toBeVisible();
+  });
+
+  test('old toolbar rows are GONE', async ({ page }) => {
+    await expect(page.locator('.chatbot__toolbarRow')).toHaveCount(0);
+    await expect(page.locator('#chatbotProvider')).toHaveCount(0);
+    await expect(page.locator('#chatbotKind')).toHaveCount(0);
+  });
+
+  test('agent type selector hidden in Ask mode', async ({ page }) => {
+    const box = page.locator('.chatbot__inputBox');
+    await expect(box).toHaveAttribute('data-mode', 'ask');
+    await expect(page.locator('[data-testid="agent-type-btn"]')).toBeHidden();
+  });
+
+  test('switching to Agent mode shows agent type selector', async ({ page }) => {
+    await page.locator('[data-testid="mode-toggle"]').click();
+    await page.locator('[data-value="agent"]').click();
+    const box = page.locator('.chatbot__inputBox');
+    await expect(box).toHaveAttribute('data-mode', 'agent');
+    await expect(page.locator('[data-testid="agent-type-btn"]')).toBeVisible();
+  });
+
+  test('attach button opens file picker', async ({ page }) => {
+    const [chooser] = await Promise.all([
+      page.waitForEvent('filechooser'),
+      page.locator('[data-testid="attach-btn"]').click(),
+    ]);
+    expect(chooser).toBeTruthy();
+  });
+
+  test('model button opens model dropdown', async ({ page }) => {
+    await page.locator('[data-testid="model-btn"]').click();
+    await expect(page.locator('.chatbot__modelDropdown')).toBeVisible();
+  });
+
+  test('model dropdown shows group headers', async ({ page }) => {
+    await page.locator('[data-testid="model-btn"]').click();
+    const dropdown = page.locator('.chatbot__modelDropdown');
+    await expect(dropdown.locator('.chatbot__modelGroup')).toHaveCount(3); // Local / API / OpenRouter
+  });
+
+  test('file too large shows error message', async ({ page }) => {
+    // Create a fake >10 MB buffer
+    const bigFile = Buffer.alloc(11 * 1024 * 1024, 'x');
+    const [chooser] = await Promise.all([
+      page.waitForEvent('filechooser'),
+      page.locator('[data-testid="attach-btn"]').click(),
+    ]);
+    await chooser.setFiles({
+      name: 'big.txt',
+      mimeType: 'text/plain',
+      buffer: bigFile,
+    });
+    await expect(page.locator('.chatbot__attachError')).toContainText('too large');
+  });
+
+  test('Enter sends message, Shift+Enter inserts newline', async ({ page }) => {
+    const input = page.locator('.chatbot__textarea');
+    await input.fill('Hello');
+    await input.press('Enter');
+    // A user bubble should appear
+    await expect(page.locator('.chatbot__msg--user').last()).toContainText('Hello');
+  });
+});


### PR DESCRIPTION
## Summary

- **HTML** (`chatbot_shell.html` Iteration 5): Replaces the old two-row toolbar (`chatbot__toolbarRow`, `#chatbotProvider`, `#chatbotKind`) with a single unified `.chatbot__inputBox` containing a textarea on top and a bottom action bar with: Ask/Agent mode toggle pill, agent-type selector pill (Agent-mode only), attach button (`+`), model selector, and send button — all wired with `data-testid` attributes for Playwright
- **CSS** (`chatbot.css` Iteration 5): Strips old toolbar/hint rules; adds styles for the unified input box, blue focus ring (`:focus-within`), pill buttons, dropdown menus, attach chip strip, attach error message, model button, send divider, and send button
- **Tests** (`tests/ui/chat-input-refactor.spec.js`): 9 Playwright tests covering layout structure, mode switching (Ask ↔ Agent), agent-type visibility, file picker trigger, model dropdown groups, file-size error, and Enter-to-send behaviour

## What's still needed before merge

- [ ] **Task 4**: Rewrite `assets/js/chatbot-widget.js` to wire up the new element IDs (`chatbotInputBox`, `modePillBtn`, `agentTypePillBtn`, `attachBtn`, `chatbotFileInput`, `modelBtn`, etc.) — the old widget references removed elements and will not function with the new HTML
- [ ] Run `npx playwright test tests/ui/chat-input-refactor.spec.js` against a live Jekyll server and confirm all 9 tests pass

## Test plan

- [ ] Jekyll site builds without errors (`bundle exec jekyll build`)
- [ ] Old `.chatbot__toolbarRow`, `#chatbotProvider`, `#chatbotKind` are absent from the DOM
- [ ] Input box renders with dark background and rounded corners
- [ ] Focus ring appears (blue border) when clicking inside the box
- [ ] All 9 Playwright tests pass after JS rewrite lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)