### PR TITLE
fix: handle UnexpectedModelBehavior + add OpenRouter provider

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,9 @@ services:
       REQUESTS_PER_MINUTE: ${REQUESTS_PER_MINUTE:-30}
       MAX_OUTPUT_TOKENS: ${MAX_OUTPUT_TOKENS:-1200}
       MAX_REQUEST_BYTES: ${MAX_REQUEST_BYTES:-200000}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      OPENROUTER_BASE_URL: ${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}
+      OPENROUTER_MODEL: ${OPENROUTER_MODEL:-google/gemini-2.5-flash}
     networks:
       - jekyll-network
 

--- a/services/llm_api/.env.example
+++ b/services/llm_api/.env.example
@@ -30,6 +30,11 @@ OLLAMA_MODEL=llama3.2
 # GEMINI_API_KEY=
 # GEMINI_MODEL=gemini-1.5-flash
 
+# OpenRouter (OpenAI-compatible proxy — supports google/gemini-2.5-flash etc.)
+# OPENROUTER_API_KEY=
+# OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+# OPENROUTER_MODEL=google/gemini-2.5-flash
+
 # Limits
 MAX_CONCURRENCY=4
 MAX_CONCURRENCY_PER_PROVIDER=2

--- a/services/llm_api/README.md
+++ b/services/llm_api/README.md
@@ -12,7 +12,7 @@ FastAPI service that generates *draft-only* D&D campaign content using PydanticA
 ## Environment variables
 Required:
 - `LLM_API_KEY` (value expected in `X-API-Key` header)
-- `LLM_PROVIDER` one of `ollama`, `openai`, `anthropic`, `gemini`, `mock`
+- `LLM_PROVIDER` one of `ollama`, `openai`, `anthropic`, `gemini`, `openrouter`, `mock`
 
 Provider-specific:
 - `OLLAMA_BASE_URL` (recommended in Docker: `http://host.docker.internal:11434`)
@@ -20,6 +20,7 @@ Provider-specific:
 - `OPENAI_API_KEY`, `OPENAI_MODEL`
 - `ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL`
 - `GEMINI_API_KEY`, `GEMINI_MODEL`
+- `OPENROUTER_API_KEY`, `OPENROUTER_BASE_URL` (default `https://openrouter.ai/api/v1`), `OPENROUTER_MODEL` (default `google/gemini-2.5-flash`)
 
 Limits/budgets:
 - `MAX_CONCURRENCY` (default: 4)
@@ -83,3 +84,17 @@ Error codes: `no_user_message` (400), `provider_not_configured` (400), `rate_lim
 
 - `GET /healthz`
 - `POST /v1/generate/{kind}` where `{kind}` in `npc|monster|encounter|chapter|location`
+
+**Example — generate NPC via OpenRouter (Gemini 2.5 Flash):**
+```bash
+# Set OPENROUTER_API_KEY in .env or export it, then:
+curl -X POST 'http://localhost:8000/v1/generate/npc' \
+  -H 'X-API-Key: your_key' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "campaign": "my-campaign",
+    "slug": "gemini-paladin",
+    "fields": {},
+    "provider": "openrouter"
+  }'
+```

--- a/services/llm_api/src/llm_api/generators/base.py
+++ b/services/llm_api/src/llm_api/generators/base.py
@@ -14,6 +14,7 @@ from typing import Any, TypeVar
 import structlog
 from pydantic import BaseModel
 from pydantic_ai import UsageLimitExceeded, UsageLimits
+from pydantic_ai.exceptions import UnexpectedModelBehavior
 from slugify import slugify
 
 from llm_api.models.requests import GenerateRequest
@@ -79,6 +80,8 @@ async def run_generation(
                   configured request or token limits.
         ApiError: ``provider_not_configured`` / ``unknown_provider`` (400) when
                   ``build_agent`` cannot satisfy the provider (propagated as-is).
+        ApiError: ``model_behavior_error`` (502) when the model returns invalid
+                  structured output after exhausting retries.
     """
     log.debug("generation.llm_call", provider=provider, prompt_length=len(user_prompt))
 
@@ -102,6 +105,18 @@ async def run_generation(
             status_code=507,
             details={"error": str(exc)},
         )
+    except UnexpectedModelBehavior as exc:
+        log.warning(
+            "generation.model_behavior_error",
+            provider=provider,
+            error=str(exc),
+        )
+        raise ApiError(
+            code="model_behavior_error",
+            message="The model failed to produce valid structured output after retries",
+            status_code=502,
+            details={"error": str(exc)},
+        ) from exc
 
     log.debug("generation.llm_done", output_type=output_type.__name__)
     return result.output  # type: ignore[return-value]

--- a/services/llm_api/src/llm_api/generators/npc.py
+++ b/services/llm_api/src/llm_api/generators/npc.py
@@ -225,7 +225,16 @@ async def generate_npc(
             return NpcDraft(title=title, slug=slug, name=title, summary="TBD", tags=[])
         user_prompt = (
             f"Campaign: {campaign}\n\nUser prompt: {request.prompt}\n\n"
-            "Return: name (full), summary (markdown), tags (list)."
+            "Respond with ONLY a JSON object (no markdown fences, no function-call wrapper).\n"
+            "Required top-level fields:\n"
+            '  "name"    — full NPC name (non-empty string)\n'
+            '  "summary" — 1–3 paragraph markdown description (non-empty string)\n'
+            '  "tags"    — list of 2–5 short descriptor strings\n\n'
+            "Example:\n"
+            '{"name": "Aldric the Grey", '
+            '"summary": "A weathered elven wizard who guards the northern pass. '
+            'He speaks little but carries ancient secrets.", '
+            '"tags": ["wizard", "elf", "mysterious"]}'
         )
         out: NpcOutput = await run_generation(
             output_type=NpcOutput,

--- a/services/llm_api/src/llm_api/providers/factory.py
+++ b/services/llm_api/src/llm_api/providers/factory.py
@@ -66,6 +66,22 @@ def build_agent(*, output_type, system_prompt: str, provider_override: str | Non
         )
         return Agent(model, output_type=output_type, system_prompt=system_prompt)
 
+    if provider == "openrouter":
+        if not settings.openrouter_api_key:
+            raise ApiError(
+                code="provider_not_configured",
+                message="OPENROUTER_API_KEY is required when provider=openrouter",
+                status_code=400,
+            )
+        model = OpenAIChatModel(
+            settings.openrouter_model,
+            provider=OpenAIProvider(
+                base_url=settings.openrouter_base_url.rstrip("/"),
+                api_key=settings.openrouter_api_key,
+            ),
+        )
+        return Agent(model, output_type=output_type, system_prompt=system_prompt)
+
     if provider == "mock":
         # Generators handle mock provider without PydanticAI.
         raise RuntimeError("mock provider must be handled by generator")

--- a/services/llm_api/src/llm_api/services/config.py
+++ b/services/llm_api/src/llm_api/services/config.py
@@ -44,6 +44,17 @@ class Settings(BaseSettings):
     gemini_api_key: str | None = Field(default=None, alias="GEMINI_API_KEY")
     gemini_model: str = Field(default="gemini-1.5-flash", alias="GEMINI_MODEL")
 
+    # OpenRouter (OpenAI-compatible proxy)
+    openrouter_api_key: str | None = Field(default=None, alias="OPENROUTER_API_KEY")
+    openrouter_base_url: str = Field(
+        default="https://openrouter.ai/api/v1",
+        alias="OPENROUTER_BASE_URL",
+    )
+    openrouter_model: str = Field(
+        default="google/gemini-2.5-flash",
+        alias="OPENROUTER_MODEL",
+    )
+
     # Limits
     max_concurrency: int = Field(default=4, alias="MAX_CONCURRENCY")
     max_concurrency_per_provider: int = Field(default=2, alias="MAX_CONCURRENCY_PER_PROVIDER")

--- a/services/llm_api/tests/test_generator_npc.py
+++ b/services/llm_api/tests/test_generator_npc.py
@@ -109,3 +109,33 @@ async def test_generate_npc_without_type_falls_back_to_legacy():
     req = GenerateRequest(prompt="A blacksmith", title="Tom")
     draft = await generate_npc(request=req, campaign="test-campaign")
     assert isinstance(draft, NpcDraft)
+
+
+@pytest.mark.asyncio
+async def test_legacy_user_prompt_includes_json_example_and_field_names():
+    """The legacy user_prompt must contain the expected output field names and a
+    concrete JSON example so small models do not return function-call shapes."""
+    from unittest.mock import patch
+
+    from llm_api.generators.npc import NpcOutput, generate_npc
+    from llm_api.models.requests import GenerateRequest
+
+    captured: dict = {}
+
+    async def _fake_run_generation(**kwargs):
+        captured["user_prompt"] = kwargs["user_prompt"]
+        return NpcOutput(
+            name="Test NPC",
+            summary="A test NPC for unit testing.",
+            tags=["test"],
+        )
+
+    with patch("llm_api.generators.npc.run_generation", side_effect=_fake_run_generation):
+        req = GenerateRequest(prompt="generate a 2nd level paladin", title="")
+        await generate_npc(request=req, campaign="test-campaign", provider_override="ollama")
+
+    prompt = captured["user_prompt"]
+    assert '"name"' in prompt, 'prompt must include "name" field example'
+    assert '"summary"' in prompt, 'prompt must include "summary" field example'
+    assert '"tags"' in prompt, 'prompt must include "tags" field example'
+    assert "JSON" in prompt.upper(), "prompt must explicitly mention JSON"

--- a/services/llm_api/tests/test_generators_base.py
+++ b/services/llm_api/tests/test_generators_base.py
@@ -58,3 +58,40 @@ async def test_run_generation_mock_raises_on_real_provider(monkeypatch):
             provider="nonexistent_provider_xyz",
             settings=Settings(),  # type: ignore[call-arg]
         )
+
+
+@pytest.mark.asyncio
+async def test_run_generation_converts_unexpected_model_behavior_to_api_error():
+    """UnexpectedModelBehavior must become a 502 ApiError, not bubble as 500."""
+    from unittest.mock import AsyncMock, patch
+
+    from pydantic import BaseModel
+    from pydantic_ai.exceptions import UnexpectedModelBehavior
+
+    from llm_api.generators.base import run_generation
+    from llm_api.services.config import Settings
+    from llm_api.services.errors import ApiError
+
+    class _Out(BaseModel):
+        name: str
+
+    with patch("llm_api.generators.base.build_agent") as mock_build:
+        mock_agent = AsyncMock()
+        mock_agent.run.side_effect = UnexpectedModelBehavior(
+            "Exceeded maximum retries (1) for output validation"
+        )
+        mock_build.return_value = mock_agent
+
+        with pytest.raises(ApiError) as exc_info:
+            await run_generation(
+                output_type=_Out,
+                system_prompt="system",
+                user_prompt="user",
+                provider="ollama",
+                settings=Settings(),  # type: ignore[call-arg]
+            )
+
+    err = exc_info.value
+    assert err.status_code == 502
+    assert err.code == "model_behavior_error"
+    assert "retries" in err.message.lower() or "model" in err.message.lower()

--- a/services/llm_api/tests/test_providers_openrouter.py
+++ b/services/llm_api/tests/test_providers_openrouter.py
@@ -1,0 +1,68 @@
+# services/llm_api/tests/test_providers_openrouter.py
+from __future__ import annotations
+
+import os
+
+import pytest
+
+os.environ.setdefault("LLM_API_KEY", "test-key")
+os.environ.setdefault("LLM_PROVIDER", "mock")
+
+
+def test_build_agent_openrouter_missing_key_raises_api_error(monkeypatch):
+    """factory.build_agent raises ApiError(400) when OPENROUTER_API_KEY is unset."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    from pydantic import BaseModel
+
+    from llm_api.providers.factory import build_agent
+    from llm_api.services.errors import ApiError
+
+    class _Out(BaseModel):
+        name: str
+
+    with pytest.raises(ApiError) as exc_info:
+        build_agent(
+            output_type=_Out,
+            system_prompt="system",
+            provider_override="openrouter",
+        )
+
+    err = exc_info.value
+    assert err.status_code == 400
+    assert err.code == "provider_not_configured"
+    assert "OPENROUTER_API_KEY" in err.message
+
+
+def test_build_agent_openrouter_returns_agent_when_key_present(monkeypatch):
+    """factory.build_agent returns a pydantic_ai Agent when OPENROUTER_API_KEY is set."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+
+    from pydantic import BaseModel
+    from pydantic_ai import Agent
+
+    from llm_api.providers.factory import build_agent
+
+    class _Out(BaseModel):
+        name: str
+
+    agent = build_agent(
+        output_type=_Out,
+        system_prompt="system",
+        provider_override="openrouter",
+    )
+    assert isinstance(agent, Agent)
+
+
+def test_settings_expose_openrouter_fields(monkeypatch):
+    """Settings correctly reads all three OPENROUTER_* env vars."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+    monkeypatch.setenv("OPENROUTER_MODEL", "google/gemini-2.5-flash")
+
+    from llm_api.services.config import Settings
+
+    s = Settings()  # type: ignore[call-arg]
+    assert s.openrouter_api_key == "sk-or-test"
+    assert s.openrouter_base_url == "https://openrouter.ai/api/v1"
+    assert s.openrouter_model == "google/gemini-2.5-flash"


### PR DESCRIPTION
Catch pydantic_ai.exceptions.UnexpectedModelBehavior in run_generation and convert it to a 502 ApiError; strengthen legacy NPC user_prompt to force JSON-only output; add OpenRouter support (settings + factory branch); update env examples, docker-compose, and README.\n\nAll Python tests pass locally (84/84).\n\nCloses #25